### PR TITLE
Fix misaligned last beat.

### DIFF
--- a/src/library/export/engineprimeexportjob.cpp
+++ b/src/library/export/engineprimeexportjob.cpp
@@ -190,7 +190,7 @@ void exportMetadata(djinterop::database* pDatabase,
         // We will treat the first bar-aligned beat as beat zero.  Find the
         // number of beats from there until the end of the track in order to
         // correctly assign an index for the last beat.
-        double lastBeatPlayPos = sampleOffsetToPlayPos(beats->findPrevBeat(sampleCount));
+        double lastBeatPlayPos = beats->findPrevBeat(sampleOffsetToPlayPos(sampleCount));
         int numBeats = beats->numBeatsInRange(firstBarAlignedBeatPlayPos, lastBeatPlayPos);
         if (numBeats > 0) {
             std::vector<djinterop::beatgrid_marker> beatgrid{


### PR DESCRIPTION
This also fixes xsco/libdjinterop#37 where Engine Prime and engine os would recalculate the BPM to a wrong value based on the beatgrid.

I'm still in the process of testing this out against my whole library but on the few tracks I tested this seems to indeed solve the issue.